### PR TITLE
feat(content): 콘텐츠 관리 계층구조 설계

### DIFF
--- a/src/main/java/com/codeit/mopl/domain/content/controller/ContentController.java
+++ b/src/main/java/com/codeit/mopl/domain/content/controller/ContentController.java
@@ -1,5 +1,13 @@
 package com.codeit.mopl.domain.content.controller;
 
-public class ContentController {
+import com.codeit.mopl.domain.content.service.ContentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/contents")
+public class ContentController {
+  private final ContentService contentService;
 }

--- a/src/main/java/com/codeit/mopl/domain/content/dto/ContentDto.java
+++ b/src/main/java/com/codeit/mopl/domain/content/dto/ContentDto.java
@@ -1,0 +1,16 @@
+package com.codeit.mopl.domain.content.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+public record ContentDto(
+    UUID id,
+    String type,
+    String title,
+    String description,
+    String thumbnailUrl,
+    List<String> tags,
+    Double averageRating,
+    Integer reviewCount,
+    Long watcherCount
+) {}

--- a/src/main/java/com/codeit/mopl/domain/content/entity/Content.java
+++ b/src/main/java/com/codeit/mopl/domain/content/entity/Content.java
@@ -1,5 +1,45 @@
 package com.codeit.mopl.domain.content.entity;
 
-public class Content {
+import com.codeit.mopl.domain.base.UpdatableEntity;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.JoinColumn;
+import jakarta.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Content extends UpdatableEntity {
+
+  @NotNull
+  @Column(nullable = false)
+  private String title;
+
+  @NotNull
+  @Column(nullable = false)
+  private String description;
+
+  private String thumbnailUrl;
+
+  @ElementCollection
+  @CollectionTable(name = "content_tags", joinColumns = @JoinColumn(name = "content_id"))
+  @Column(name = "tag")
+  private List<String> tags = new ArrayList<>();
+
+  @NotNull
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private ContentType contentType;
+
+  private Double averageRating = 0.0;
+  private Integer reviewCount = 0;
 }

--- a/src/main/java/com/codeit/mopl/domain/content/entity/ContentType.java
+++ b/src/main/java/com/codeit/mopl/domain/content/entity/ContentType.java
@@ -1,0 +1,14 @@
+package com.codeit.mopl.domain.content.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ContentType {
+  MOVIE("movie"),
+  TV("tv"),
+  SPORTS("sports");
+
+  private final String type;
+}

--- a/src/main/java/com/codeit/mopl/domain/content/mapper/ContentMapper.java
+++ b/src/main/java/com/codeit/mopl/domain/content/mapper/ContentMapper.java
@@ -1,0 +1,8 @@
+package com.codeit.mopl.domain.content.mapper;
+
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface ContentMapper {
+
+}

--- a/src/main/java/com/codeit/mopl/domain/content/repository/ContentRepository.java
+++ b/src/main/java/com/codeit/mopl/domain/content/repository/ContentRepository.java
@@ -1,5 +1,9 @@
 package com.codeit.mopl.domain.content.repository;
 
-public class ContentRepository {
+import com.codeit.mopl.domain.content.entity.Content;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ContentRepository extends JpaRepository<Content, UUID> {
 
 }

--- a/src/main/java/com/codeit/mopl/domain/content/service/ContentService.java
+++ b/src/main/java/com/codeit/mopl/domain/content/service/ContentService.java
@@ -1,5 +1,11 @@
 package com.codeit.mopl.domain.content.service;
 
-public class ContentService {
+import com.codeit.mopl.domain.content.repository.ContentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
+@Service
+@RequiredArgsConstructor
+public class ContentService {
+  private final ContentRepository contentRepository;
 }


### PR DESCRIPTION
## 📌 PR 내용 요약
- 콘텐츠 관리에 사용될 기본 계층을 설계하였습니다.
-  entity, dto, comtroller, service, repository, mapper 구현
- 기본 틀만 만들어 놨고 추후에 기본 기능 구현하면 매서드 추가할 예정입니다. 

## 🔗 관련 이슈
- Closes #45 

## 🖼️ 스크린샷 (선택)


## 📚 참고자료 (선택)
- 

## 🙋 리뷰어에게 요청사항
- 
