### PR TITLE
[User] (feat/023) 유저 상세 정보 조회 기능 구현

### DIFF
--- a/src/main/java/com/codeit/mopl/domain/user/controller/UserController.java
+++ b/src/main/java/com/codeit/mopl/domain/user/controller/UserController.java
@@ -38,4 +38,11 @@ public class UserController {
         log.info("비밀번호 변경 응답 userId = {}", userId);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
+
+    @GetMapping("/{userId}")
+    public ResponseEntity findUser(@PathVariable UUID userId) {
+        log.info("[사용자 관리] 사용자 상세 정보 조회 호출 userId = {}", userId);
+        UserDto response = userService.findUser(userId);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
 }

--- a/src/main/java/com/codeit/mopl/domain/user/service/UserService.java
+++ b/src/main/java/com/codeit/mopl/domain/user/service/UserService.java
@@ -6,13 +6,18 @@ import com.codeit.mopl.domain.user.dto.response.UserDto;
 import com.codeit.mopl.domain.user.entity.User;
 import com.codeit.mopl.domain.user.mapper.UserMapper;
 import com.codeit.mopl.domain.user.repository.UserRepository;
+import com.codeit.mopl.exception.user.ErrorCode;
+import com.codeit.mopl.exception.user.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Map;
 import java.util.UUID;
 
 @Service
@@ -51,6 +56,14 @@ public class UserService {
         log.info("유저 비밀번호 변경 완료 userId = {}", userId);
     }
 
+    public UserDto findUser(UUID userId) {
+        log.info("[사용자 관리] 회원 정보 조회 동작 userId = {}", userId);
+        User findUser = getValidUserByUserId(userId);
+        UserDto userDto = userMapper.toDto(findUser);
+        log.info("[사용자 관리] 회원 정보 조회 성공 userId = {}", userDto.id());
+        return userDto;
+    }
+
     private void validateEmail(String email) {
         if (userRepository.existsByEmail(email)) {
             log.warn("이메일 중복 가입 email = {}", email);
@@ -69,8 +82,8 @@ public class UserService {
     private User getValidUserByUserId(UUID userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> {
-                    log.info("해당 유저를 찾을 수 없음 userId = {}", userId);
-                    throw new UsernameNotFoundException("User not found");
+                    log.warn("[사용자 관리] 해당 유저를 찾을 수 없음 userId = {}", userId);
+                    throw new UserNotFoundException(ErrorCode.USER_NOT_FOUND, Map.of("userId",userId));
                 });
     }
 }

--- a/src/main/java/com/codeit/mopl/exception/global/ErrorCode.java
+++ b/src/main/java/com/codeit/mopl/exception/global/ErrorCode.java
@@ -6,11 +6,16 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
-public enum ErrorCode{
+public enum ErrorCode implements ErrorCodeInterface{
 
   INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "입력값이 올바르지 않습니다."),
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러가 발생했습니다.");
 
   private final HttpStatus status;
   private final String message;
+
+  @Override
+  public String getName() {
+    return this.name();
+  }
 }

--- a/src/main/java/com/codeit/mopl/exception/global/ErrorCodeInterface.java
+++ b/src/main/java/com/codeit/mopl/exception/global/ErrorCodeInterface.java
@@ -1,0 +1,9 @@
+package com.codeit.mopl.exception.global;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCodeInterface {
+    String getName();
+    String getMessage();
+    HttpStatus getStatus();
+}

--- a/src/main/java/com/codeit/mopl/exception/global/GlobalExceptionHandler.java
+++ b/src/main/java/com/codeit/mopl/exception/global/GlobalExceptionHandler.java
@@ -12,7 +12,7 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ErrorResponse> handleMoplException(MoplException e) {
     log.error(e.getMessage(), e);
 
-    ErrorResponse errorResponse = new ErrorResponse(e.getErrorCode().name(), e.getErrorCode().getMessage(), e.getDetails(), e.getTimestamp());
+    ErrorResponse errorResponse = new ErrorResponse(e.getErrorCode().getName(), e.getErrorCode().getMessage(), e.getDetails(), e.getTimestamp());
 
     return ResponseEntity.status(e.getErrorCode().getStatus()).body(errorResponse);
   }

--- a/src/main/java/com/codeit/mopl/exception/global/MoplException.java
+++ b/src/main/java/com/codeit/mopl/exception/global/MoplException.java
@@ -8,10 +8,10 @@ import lombok.Getter;
 public class MoplException extends RuntimeException {
 
   final LocalDateTime timestamp;
-  final ErrorCode errorCode;
+  final ErrorCodeInterface errorCode;
   final Map<String, Object> details;
 
-  public MoplException(ErrorCode errorCode, Map<String, Object> details) {
+  public MoplException(ErrorCodeInterface errorCode, Map<String, Object> details) {
     this.timestamp = LocalDateTime.now();
     this.errorCode = errorCode;
     this.details = details;

--- a/src/main/java/com/codeit/mopl/exception/user/ErrorCode.java
+++ b/src/main/java/com/codeit/mopl/exception/user/ErrorCode.java
@@ -1,15 +1,33 @@
 package com.codeit.mopl.exception.user;
 
+import com.codeit.mopl.exception.global.ErrorCodeInterface;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
-@Getter
-public enum ErrorCode {
-    USER_NOT_FOUND("유저를 찾을 수 없습니다.",404);
-    private String message;
-    private int code;
+public enum ErrorCode implements ErrorCodeInterface {
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다.");
 
-    ErrorCode(String message, int code) {
+    private final HttpStatus status;
+    private final String message;
+
+    ErrorCode(HttpStatus status, String message) {
+        this.status = status;
         this.message = message;
-        this.code = code;
+    }
+
+
+    @Override
+    public String getName() {
+        return this.name();
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
     }
 }

--- a/src/main/java/com/codeit/mopl/exception/user/UserEmailAlreadyExistsException.java
+++ b/src/main/java/com/codeit/mopl/exception/user/UserEmailAlreadyExistsException.java
@@ -1,0 +1,9 @@
+package com.codeit.mopl.exception.user;
+
+import java.util.Map;
+
+public class UserEmailAlreadyExistsException extends UserException{
+    public UserEmailAlreadyExistsException(ErrorCode errorCode, Map<String, Object> details){
+        super(errorCode, details);
+    }
+}

--- a/src/main/java/com/codeit/mopl/exception/user/UserException.java
+++ b/src/main/java/com/codeit/mopl/exception/user/UserException.java
@@ -1,0 +1,11 @@
+package com.codeit.mopl.exception.user;
+
+import com.codeit.mopl.exception.global.MoplException;
+
+import java.util.Map;
+
+public class UserException extends MoplException {
+    public UserException(ErrorCode errorCode, Map<String, Object> details) {
+        super(errorCode, details);
+    }
+}

--- a/src/main/java/com/codeit/mopl/exception/user/UserNotFoundException.java
+++ b/src/main/java/com/codeit/mopl/exception/user/UserNotFoundException.java
@@ -1,0 +1,10 @@
+package com.codeit.mopl.exception.user;
+
+import java.util.Map;
+
+public class UserNotFoundException extends UserException{
+
+    public UserNotFoundException(ErrorCode errorCode, Map<String, Object> details) {
+        super(errorCode,details);
+    }
+}

--- a/src/test/java/com/codeit/mopl/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/codeit/mopl/domain/user/repository/UserRepositoryTest.java
@@ -7,7 +7,6 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 
 @DataJpaTest
-@EnableJpaAuditing
 public class UserRepositoryTest {
     @Autowired
     private UserRepository userRepository;

--- a/src/test/java/com/codeit/mopl/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/codeit/mopl/domain/user/service/UserServiceTest.java
@@ -6,19 +6,23 @@ import com.codeit.mopl.domain.user.entity.Role;
 import com.codeit.mopl.domain.user.entity.User;
 import com.codeit.mopl.domain.user.mapper.UserMapper;
 import com.codeit.mopl.domain.user.repository.UserRepository;
+import com.codeit.mopl.exception.user.UserNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
@@ -66,5 +70,41 @@ public class UserServiceTest {
         Exception exception = assertThrows(IllegalArgumentException.class, () -> userService.create(request));
 
         assertEquals("Email already exists", exception.getMessage());
+    }
+
+    @DisplayName("올바른 유저 아이디를 조회하면 정상적으로 해당 유저의 상세정보가 표시된다.")
+    @Test
+    void checkUserInformationShouldSucceedWhenValidateUserId() {
+        // given
+        User findUser = new User("test@example.com","testPassword","test");
+        UUID uuid = UUID.randomUUID();
+        UserDto findUserDto = new UserDto(uuid, LocalDateTime.now(), "test@example.com","test",null, Role.USER, false);
+        given(userRepository.findById(any(UUID.class))).willReturn(Optional.of(findUser));
+        given(userMapper.toDto(findUser)).willReturn(findUserDto);
+
+        // when
+        UserDto responseUserDto = userService.findUser(uuid);
+
+        // then
+        assertEquals(responseUserDto.email(), findUser.getEmail());
+        assertEquals(responseUserDto.role(), Role.USER);
+        assertEquals(responseUserDto.id(), uuid);
+        assertEquals(responseUserDto.name(), findUser.getName());
+    }
+
+    @DisplayName("존재하지 않는 유저ID로 유저 정보를 조회하면 404 NOT_FOUND 예외가 발생한다")
+    @Test
+    void checkUserInformationShouldFailWhenUserIdNotFound() {
+        // given
+        UUID uuid = UUID.randomUUID();
+        given(userRepository.findById(any(UUID.class))).willReturn(Optional.empty());
+
+        // when
+        UserNotFoundException exception = assertThrows(UserNotFoundException.class, () -> {
+            userService.findUser(uuid);
+        });
+
+        assertEquals("유저를 찾을 수 없습니다.", exception.getErrorCode().getMessage());
+        assertEquals(HttpStatus.NOT_FOUND, exception.getErrorCode().getStatus());
     }
 }


### PR DESCRIPTION
## PR 제목 규칙
[User] (feat/023) 유저 상세 정보 조회 기능 구현

## 📌 PR 내용 요약
- 유저 상세 정보 조회 기능 구현
- 테스트 코드 작성
- ErrorCode Enum 인터페이스 추상화

## 🔗 관련 이슈
- Closes #23

## 🙋 리뷰어에게 요청사항
- Interface는 일단 global.ErrorCode를 기반으로 작성하였고 global.ErrorCode랑 User.ErrorCode만 수정하였습니다.
- Enum.name 은 interface에서 사용이 불가능해서 getName() 메서드를 추가로 작성했습니다.
  - name으로 ErrorResponse 넘기던 부분도 getName()으로 수정하였습니다
- 따로 Issue로 리팩토링을 만들어서 기존 코드는 그대로 놔두었습니다. 추후 리팩토링 예정입니다
