### PR TITLE
[CI/CD] (feat/39) cd cache-from 제거

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -55,7 +55,7 @@ jobs:
           tags: |
             ${{ env.REPO_URI }}:${{ steps.set-tag.outputs.image_tag }}
             ${{ env.REPO_URI }}:latest
-          cache-from: type=registry, ref=${{ env.REPO_URI }}:buildcache
+#          cache-from: type=registry, ref=${{ env.REPO_URI }}:buildcache
           cache-to: type=registry, ref=${{ env.REPO_URI }}:buildcache, mode=max
           platforms: linux/amd64
 


### PR DESCRIPTION
## 📌 PR 내용 요약
- 첫 빌드 때는 캐싱된 게 없어서 `cache-from` 제거 (ref 오류 해결)

## 🔗 관련 이슈
- Closes #39

## 🙋 리뷰어에게 요청사항
- 
