### PR TITLE
[CI/CD] (fix/187) jacoco 생성 안되는 문제 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.5.7'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'jacoco'
 }
 
 group = 'com.codeit'

--- a/src/test/java/com/codeit/mopl/security/config/TestSecurityConfig.java
+++ b/src/test/java/com/codeit/mopl/security/config/TestSecurityConfig.java
@@ -6,8 +6,8 @@ import com.codeit.mopl.security.CustomUserDetailsService;
 import com.codeit.mopl.security.jwt.JwtRegistry;
 import com.codeit.mopl.security.jwt.JwtTokenProvider;
 import com.codeit.mopl.security.jwt.filter.JwtAuthenticationFilter;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
 import org.springframework.security.config.Customizer;
@@ -23,7 +23,7 @@ import org.springframework.security.web.access.AccessDeniedHandlerImpl;
 import org.springframework.security.web.authentication.Http403ForbiddenEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
-@Configuration
+@TestConfiguration
 @EnableMethodSecurity
 public class TestSecurityConfig {
 


### PR DESCRIPTION
## 📌 PR 내용 요약
- build.gradle에 jacoco 플러그인 추가
- `contextLoads()`에 실패해서 jacoco 테스트 결과를 생성하지 못함
  - TestSecurityConfig을 TestConfiguration으로 변경

## 🔗 관련 이슈
- Closes #187



## 🙋 리뷰어에게 요청사항
- 
