### PR TITLE
[팔로우] (feat/82) 특정 유저의 팔로워 수 조회 API 단위 테스트

### DIFF
--- a/src/test/java/com/codeit/mopl/domain/follow/service/FollowServiceTest.java
+++ b/src/test/java/com/codeit/mopl/domain/follow/service/FollowServiceTest.java
@@ -10,8 +10,10 @@ import com.codeit.mopl.domain.notification.service.NotificationService;
 import com.codeit.mopl.domain.user.entity.User;
 import com.codeit.mopl.domain.user.repository.UserRepository;
 import com.codeit.mopl.event.event.FollowerIncreaseEvent;
+import com.codeit.mopl.exception.follow.FollowDtoIsNullException;
 import com.codeit.mopl.exception.follow.FollowDuplicateException;
 import com.codeit.mopl.exception.follow.FollowSelfProhibitedException;
+import com.codeit.mopl.exception.user.UserIdIsNullException;
 import com.codeit.mopl.exception.user.UserNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -28,10 +30,10 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -182,7 +184,7 @@ class FollowServiceTest {
 
         // when & then
         assertThatThrownBy(() -> followService.increaseFollowerCount(null))
-                .isInstanceOf(IllegalArgumentException.class);
+                .isInstanceOf(FollowDtoIsNullException.class);
     }
 
     @Test


### PR DESCRIPTION
## 📌 PR 내용 요약
- 특정 유저의 팔로워 수 조회 API 단위 테스트 구현

## 🔗 관련 이슈
- Closes #82 

## 🙋 리뷰어에게 요청사항
- #251 병합 후 병합하겠습니다.
