### PR TITLE
[팔로우 관리] (feat/84) 팔로우 삭제 단위 테스트 추가

### DIFF
--- a/src/main/java/com/codeit/mopl/domain/follow/service/FollowService.java
+++ b/src/main/java/com/codeit/mopl/domain/follow/service/FollowService.java
@@ -65,6 +65,14 @@ public class FollowService {
         return dto;
     }
 
+    @Transactional
+    public void increaseFollowerCount(UUID followeeId) {
+        log.info("[팔로우 관리] 팔로워 증가 이벤트 처리 시작 - followeeId: {}", followeeId);
+        User followee = getUserById(followeeId);
+        followee.increaseFollowerCount();
+        log.info("[팔로우 관리] 팔로워 증가 이벤트 처리 완료 - followeeId: {}", followeeId);
+    }
+
     @Transactional(readOnly = true)
     public boolean isFollowedByMe(UUID followerId, UUID followeeId) {
         log.info("[팔로우 관리] 특정 유저를 내가 팔로우하는지 여부 조회 시작 - followerId: {}, followeeId: {}", followerId, followeeId);
@@ -101,14 +109,6 @@ public class FollowService {
         UUID followeeId = follow.getFollowee().getId();
         eventPublisher.publishEvent(new FollowerDecreaseEvent(followeeId));
         log.info("[팔로우 관리] 팔로우 삭제 완료 - followId: {}", followId);
-    }
-
-    @Transactional
-    public void increaseFollowerCount(UUID followeeId) {
-        log.info("[팔로우 관리] 팔로워 증가 이벤트 처리 시작 - followeeId: {}", followeeId);
-        User followee = getUserById(followeeId);
-        followee.increaseFollowerCount();
-        log.info("[팔로우 관리] 팔로워 증가 이벤트 처리 완료 - followeeId: {}", followeeId);
     }
 
     @Transactional


### PR DESCRIPTION
## 📌 PR 내용 요약
- 팔로우 삭제 단위 테스트: 성공, 실패
- 팔로우 삭제 이벤트 처리용 서비스 메서드: 성공, 실패

## 🔗 관련 이슈
- Closes #84 

## 🙋 리뷰어에게 요청사항
- #274 병합 이후 병합 예정입니다.
