### PR TITLE
[인증/인가] (refactor/318) TestSecurityConfig 설정 변경

### DIFF
--- a/src/test/java/com/codeit/mopl/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/codeit/mopl/domain/user/controller/UserControllerTest.java
@@ -11,6 +11,7 @@ import com.codeit.mopl.domain.user.service.UserService;
 import com.codeit.mopl.security.config.TestSecurityConfig;
 import com.codeit.mopl.security.jwt.JwtRegistry;
 import com.codeit.mopl.security.jwt.JwtTokenProvider;
+import com.codeit.mopl.security.jwt.handler.JwtAuthenticationEntryPoint;
 import com.codeit.mopl.util.WithCustomMockUser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
@@ -64,6 +65,9 @@ public class UserControllerTest {
 
     @MockitoBean
     private JpaMetamodelMappingContext jpaMappingContext;
+
+    @MockitoBean
+    private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     private static final UUID TEST_UUID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
     private static final UserDto USER_DTO = new UserDto(TEST_UUID,LocalDateTime.now(),"test@test.com","testName",null,Role.USER,false);

--- a/src/test/java/com/codeit/mopl/security/config/TestSecurityConfig.java
+++ b/src/test/java/com/codeit/mopl/security/config/TestSecurityConfig.java
@@ -6,6 +6,7 @@ import com.codeit.mopl.security.CustomUserDetailsService;
 import com.codeit.mopl.security.jwt.JwtRegistry;
 import com.codeit.mopl.security.jwt.JwtTokenProvider;
 import com.codeit.mopl.security.jwt.filter.JwtAuthenticationFilter;
+import com.codeit.mopl.security.jwt.handler.JwtAuthenticationEntryPoint;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
@@ -31,7 +32,8 @@ public class TestSecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http,
                                            JwtTokenProvider jwtTokenProvider,
                                            UserDetailsService customUserDetailsService,
-                                           JwtRegistry jwtRegistry) throws Exception {
+                                           JwtRegistry jwtRegistry,
+                                           JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint) throws Exception {
         http
 //                .csrf(csrf -> csrf
 //                        .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
@@ -47,7 +49,7 @@ public class TestSecurityConfig {
                 )
                 .cors(Customizer.withDefaults())
                 .exceptionHandling(ex -> ex
-                        .authenticationEntryPoint(new Http403ForbiddenEntryPoint())
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)
                         .accessDeniedHandler(new AccessDeniedHandlerImpl())
                 )
                 .authorizeHttpRequests(authorize -> authorize


### PR DESCRIPTION
## PR 제목 규칙
[인증/인가] (refactor/318) TestSecurityConfig 설정 변경

## 📌 PR 내용 요약
- TestSecurityConfig 설정 변경에 따라 TestSecurityConfig를 사용하는 Controller에서 @MockitoBean private JwtAuthenticationEntryPoint 추가 필요
- 
## 🔗 관련 이슈
- Closes #318

## 🙋 리뷰어에게 요청사항
- ***TestSecurityConfig 변경에 따라 기존의 TestSecurityConfig를 사용하시던 ControllerTest가 계시면 `@MockitoBean` 추가 필요***
