### PR TITLE
[CI/CD] (bug/322) 첫 빌드 cache-from 제거

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,11 +42,6 @@ jobs:
         id: set-tag
         run: echo "image_tag=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
 
-      - name: Debug REPO_URI
-        run: |
-          echo "REPO_URI=${REPO_URI}"
-          echo "Literal: $REPO_URI"
-
       ## 도커 빌드 & 캐싱
       - name: 도커 빌드
         uses: docker/build-push-action@v5
@@ -56,7 +51,7 @@ jobs:
           tags: |
             ${{ env.REPO_URI }}:${{ steps.set-tag.outputs.image_tag }}
             ${{ env.REPO_URI }}:latest
-          cache-from: type=registry, ref=${{ env.REPO_URI }}:buildcache
+#          cache-from: type=registry, ref=${{ env.REPO_URI }}:buildcache
           cache-to: type=registry, ref=${{ env.REPO_URI }}:buildcache, mode=max
           platforms: linux/amd64
 


### PR DESCRIPTION
## 📌 PR 내용 요약
- Buildx가 생성한 `:buildcache` 이미지가 없어서 캐싱에 실패한 것으로 추정
- `cache-from` 옵션 주석 처리, `cache-to`만 시도

## 🔗 관련 이슈
- Closes #322


## 🙋 리뷰어에게 요청사항
- 
