### PR TITLE
[CI/CD] (bug/322) CD cache-from 옵션 다시 추가

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -51,7 +51,7 @@ jobs:
           tags: |
             ${{ env.REPO_URI }}:${{ steps.set-tag.outputs.image_tag }}
             ${{ env.REPO_URI }}:latest
-#          cache-from: type=registry,ref=${{ env.REPO_URI }}:buildcache
+          cache-from: type=registry,ref=${{ env.REPO_URI }}:buildcache
           cache-to: type=registry,ref=${{ env.REPO_URI }}:buildcache,mode=max
           platforms: linux/amd64
 


### PR DESCRIPTION
## 📌 PR 내용 요약
- 첫 번째 캐싱 이미지 생성에 성공하였으므로 `cache-from` 옵션을 다시 추가하여 캐싱 기능 완전히 추가

## 🔗 관련 이슈
- Closes #322 

## 🙋 리뷰어에게 요청사항
- 
