### PR TITLE
[CI/CD] (feat/310) Subscription에서 누락된 subscribedAt 엔티티 schema에 추가

### DIFF
--- a/src/main/java/com/codeit/mopl/domain/playlist/subscription/Subscription.java
+++ b/src/main/java/com/codeit/mopl/domain/playlist/subscription/Subscription.java
@@ -3,10 +3,7 @@ package com.codeit.mopl.domain.playlist.subscription;
 import com.codeit.mopl.domain.base.UpdatableEntity;
 import com.codeit.mopl.domain.playlist.entity.Playlist;
 import com.codeit.mopl.domain.user.entity.User;
-import jakarta.persistence.Entity;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -26,5 +23,6 @@ public class Subscription extends UpdatableEntity {
     @ManyToOne
     private User subscriber;
 
+    @Column(name = "subscribed_at")
     private LocalDateTime subscribedAt;
 }

--- a/src/main/resources/schema-pg.sql
+++ b/src/main/resources/schema-pg.sql
@@ -76,6 +76,7 @@ CREATE TABLE IF NOT EXISTS playlist_subscriptions
     updated_at TIMESTAMP,
     subscriber_id UUID NOT NULL,
     playlist_id UUID NOT NULL,
+    subscribed_at TIMESTAMP,
 
     FOREIGN KEY (subscriber_id) REFERENCES users(id) ON DELETE CASCADE,
     FOREIGN KEY (playlist_id) REFERENCES playlists(id) ON DELETE CASCADE,

--- a/src/test/resources/schema-h2.sql
+++ b/src/test/resources/schema-h2.sql
@@ -73,6 +73,7 @@ CREATE TABLE IF NOT EXISTS playlist_subscriptions
     updated_at TIMESTAMP,
     subscriber_id UUID NOT NULL,
     playlist_id UUID NOT NULL,
+    subscribed_at TIMESTAMP,
 
     FOREIGN KEY (subscriber_id) REFERENCES users(id) ON DELETE CASCADE,
     FOREIGN KEY (playlist_id) REFERENCES playlists(id) ON DELETE CASCADE,


### PR DESCRIPTION
## 📌 PR 내용 요약
- `schema-pg.sql`, `schema-h2.sql`, RDS에서 `playlist_subscriptions` 테이블에  `subscribed_at` 필드 추가
- subscribedAt에 column name 추가: subscribed_at

## 🔗 관련 이슈
- Closes #310 

## 🙋 리뷰어에게 요청사항
- 
