### PR TITLE
[CI/CD] (bug/365) ElastiCache 배포 이슈 해결 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ COPY --from=builder --chown=app:app /app/build/libs/*.jar app.jar
 USER app
 
 # 포트 노출
-EXPOSE 80
+EXPOSE 8081
 
 # 실행 명령
 ENTRYPOINT ["sh", "-c", "java ${JVM_OPTS} -jar app.jar"]

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,5 +1,5 @@
 server:
-  port: 80
+  port: 8081
 
 spring:
   datasource:


### PR DESCRIPTION
## 📌 PR 내용 요약
- 80으로 바인딩 실패 -> 관리자 권한 없음
- 운영환경의 포트를 8081로 변경

## 🔗 관련 이슈
- Closes #365

## 🙋 리뷰어에게 요청사항
- 
