### PR TITLE
[팔로우] (feat/88) 팔로우 삭제 컨트롤러 테스트 추가

### DIFF
--- a/src/test/java/com/codeit/mopl/domain/follow/controller/FollowControllerTest.java
+++ b/src/test/java/com/codeit/mopl/domain/follow/controller/FollowControllerTest.java
@@ -35,10 +35,8 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(FollowController.class)
 @ActiveProfiles("test")


### PR DESCRIPTION
## 📌 PR 내용 요약
-  팔로우 삭제 컨트롤러 테스트 추가
- `401`, `403`은 통합 테스트 예정

## 🔗 관련 이슈
- Closes #88 

## 🙋 리뷰어에게 요청사항
- 
