### PR TITLE
[설정] (fix/419) CacheConfig ObjectMapper 오류 수정

### DIFF
--- a/src/main/java/com/codeit/mopl/config/CacheConfig.java
+++ b/src/main/java/com/codeit/mopl/config/CacheConfig.java
@@ -1,27 +1,38 @@
 package com.codeit.mopl.config;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
+
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
-import org.springframework.data.redis.serializer.RedisSerializationContext.SerializationPair;
-import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 
 @Configuration
 @EnableCaching
 public class CacheConfig {
 
   @Bean
-  public RedisCacheConfiguration redisCacheConfiguration() {
-    GenericJackson2JsonRedisSerializer serializer =
-        new GenericJackson2JsonRedisSerializer();
+  public RedisCacheConfiguration redisCacheConfiguration(ObjectMapper objectMapper) {
+    ObjectMapper redisObjectMapper = objectMapper.copy();
+    redisObjectMapper.activateDefaultTyping(
+            LaissezFaireSubTypeValidator.instance,
+            ObjectMapper.DefaultTyping.EVERYTHING,
+            JsonTypeInfo.As.PROPERTY
+    );
 
     return RedisCacheConfiguration.defaultCacheConfig()
-        .serializeKeysWith(SerializationPair.fromSerializer(new StringRedisSerializer()))
-        .serializeValuesWith(SerializationPair.fromSerializer(serializer))
-        .entryTtl(Duration.ofMinutes(5));
+            .serializeValuesWith(
+                    RedisSerializationContext.SerializationPair.fromSerializer(
+                            new GenericJackson2JsonRedisSerializer(redisObjectMapper)
+                    )
+            )
+            .entryTtl(Duration.ofMinutes(5))
+            .disableCachingNullValues();
   }
+
 }


### PR DESCRIPTION
## PR 제목 규칙
[설정] (fix/419) CacheConfig ObjectMapper 오류 수정

## 📌 PR 내용 요약
- CacheConfig ObjectMapper 오류 수정
  - LocalDateTime 매핑 오류 수정

## 🔗 관련 이슈
- Closes #419 

## 🙋 리뷰어에게 요청사항
- Discodeit에서 사용하던 Config 그대로 가져왔습니다
