### PR TITLE
[플레이리스트,메세지] (Fix/423) SortBy enum 바인딩 실패 문제 해결을 위한 컨버터 추가

### DIFF
--- a/src/main/java/com/codeit/mopl/domain/message/converter/SortByConverter.java
+++ b/src/main/java/com/codeit/mopl/domain/message/converter/SortByConverter.java
@@ -1,6 +1,6 @@
 package com.codeit.mopl.domain.message.converter;
 
-import com.codeit.mopl.domain.playlist.entity.SortBy;
+import com.codeit.mopl.domain.message.conversation.entity.SortBy;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
 
@@ -8,11 +8,20 @@ import org.springframework.stereotype.Component;
 public class SortByConverter implements Converter<String, SortBy> {
     @Override
     public SortBy convert(String source) {
+        if (source == null || source.trim().isEmpty()) {
+            throw new IllegalArgumentException("SortBy 값은 null이거나 빈 값일 수 없습니다");
+        }
+
         for (SortBy v : SortBy.values()) {
             if (v.getValue().equalsIgnoreCase(source)) {
                 return v;
             }
         }
-        return SortBy.valueOf(source.toUpperCase());
+        try {
+            return SortBy.valueOf(source.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "유효하지 않은 SortBy 값입니다: " + source, e);
+        }
     }
 }

--- a/src/main/java/com/codeit/mopl/domain/playlist/converter/SortByConverter.java
+++ b/src/main/java/com/codeit/mopl/domain/playlist/converter/SortByConverter.java
@@ -8,11 +8,20 @@ import org.springframework.stereotype.Component;
 public class SortByConverter implements Converter<String, SortBy> {
     @Override
     public SortBy convert(String source) {
+        if (source == null || source.trim().isEmpty()) {
+            throw new IllegalArgumentException("SortBy 값은 null이거나 빈 값일 수 없습니다");
+        }
+
         for (SortBy v : SortBy.values()) {
             if (v.getValue().equalsIgnoreCase(source)) {
                 return v;
             }
         }
-        return SortBy.valueOf(source.toUpperCase());
+        try {
+            return SortBy.valueOf(source.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "유효하지 않은 SortBy 값입니다: " + source, e);
+        }
     }
 }


### PR DESCRIPTION
## 📌 PR 내용 요약
- sortBy 사용하는 도메인들에 컨버터가 필요할 듯한데 GloblaEnumConverter 만드는 것도 고려해보면 좋을 것 같습니다.
- 일단 오늘 통합테스트를 위해 담당 도메인에 각각 컨버터 추가하여 PR올립니다!

## 🔗 관련 이슈
- Closes #423 

## 🖼️ 스크린샷 (선택)


## 📚 참고자료 (선택)
- 

## 🙋 리뷰어에게 요청사항
- 
