### PR TITLE
[Follow] (bug/444) 팔로우 이벤트에 대한 카프카 이벤트 리스너 테스트 코드 수정

### DIFF
--- a/src/test/java/com/codeit/mopl/event/KafkaEventListenerTest.java
+++ b/src/test/java/com/codeit/mopl/event/KafkaEventListenerTest.java
@@ -5,13 +5,9 @@ import com.codeit.mopl.event.event.FollowerDecreaseEvent;
 import com.codeit.mopl.event.event.FollowerIncreaseEvent;
 import com.codeit.mopl.event.event.NotificationCreateEvent;
 import com.codeit.mopl.event.listener.KafkaEventListener;
-import com.codeit.mopl.exception.follow.FollowIdIsNullException;
 import com.codeit.mopl.exception.follow.FolloweeIdIsNullException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.nio.charset.StandardCharsets;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
@@ -25,6 +21,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.MDC;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.SendResult;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -140,19 +140,6 @@ class KafkaEventListenerTest {
   }
 
   @Test
-  @DisplayName("FollowerIncreaseEvent Kafka 메시지 전송 실패 - followId는 null이 될 수 없음")
-  void onFollowerIncreaseEvent_FollowIdIsNull_ThrowsException() {
-    // given
-    FollowerIncreaseEvent event = new FollowerIncreaseEvent(null, null);
-
-    // when & then
-    assertThatThrownBy(() -> kafkaEventListener.on(event))
-            .isInstanceOf(FollowIdIsNullException.class);
-
-    verify(kafkaTemplate, never()).send(any(ProducerRecord.class));
-  }
-
-  @Test
   @DisplayName("FollowerIncreaseEvent Kafka 메시지 전송 실패 - followeeId는 null이 될 수 없음")
   void onFollowerIncreaseEvent_FolloweeIdIsNull_ThrowsException() {
     // given
@@ -200,19 +187,6 @@ class KafkaEventListenerTest {
     assertThat(typeHeader).isNotNull();
     assertThat(new String(typeHeader.value(), StandardCharsets.UTF_8))
             .isEqualTo(event.getClass().getSimpleName());
-  }
-
-  @Test
-  @DisplayName("FollowerDecreaseEvent Kafka 메시지 전송 실패 - followId는 null이 될 수 없음")
-  void onFollowerDecreaseEvent_FollowIdIsNull_ThrowsException() {
-    // given
-    FollowerDecreaseEvent event = new FollowerDecreaseEvent(null, null);
-
-    // when & then
-    assertThatThrownBy(() -> kafkaEventListener.on(event))
-            .isInstanceOf(FollowIdIsNullException.class);
-
-    verify(kafkaTemplate, never()).send(any(ProducerRecord.class));
   }
 
   @Test


### PR DESCRIPTION
## 📌 PR 내용 요약
- 로직에 없는 실패 테스트 삭제 (`followId` null 실패 테스트 2건 삭제)

## 🔗 관련 이슈
- Closes #444

## 🙋 리뷰어에게 요청사항
- 
