### PR TITLE
[팔로우] (bug/535) 컬럼명 변경 status -> followStatus

### DIFF
--- a/src/main/java/com/codeit/mopl/domain/follow/entity/Follow.java
+++ b/src/main/java/com/codeit/mopl/domain/follow/entity/Follow.java
@@ -34,7 +34,7 @@ public class Follow extends BaseEntity {
     private User followee;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false)
+    @Column(name = "followStatus", nullable = false)
     private FollowStatus followStatus = FollowStatus.PENDING;
 
     @Column(name = "retry_count", nullable = false)


### PR DESCRIPTION
## 📌 PR 내용 요약
- `@Column`명이 `status`로 유지되어 있어 해당 컬럼을 찾지 못한 배포 오류 해결
  - `status` -> `followStatus` 

## 🔗 관련 이슈
- Closes #535 

## 🙋 리뷰어에게 요청사항
- 
