### PR TITLE
[알림] (fix/550) 유저 권한 변경 시 알림 메시지 수정

### DIFF
--- a/src/main/java/com/codeit/mopl/domain/notification/template/NotificationTemplate.java
+++ b/src/main/java/com/codeit/mopl/domain/notification/template/NotificationTemplate.java
@@ -74,7 +74,7 @@ public enum NotificationTemplate {
     @Override
     public NotificationMessage build(RoleChangedContext ctx) {
       String title = "내 권한이 변경되었어요.";
-      String josa = BetterKorean.with(ctx.afterRole()).get_으로_로_with();
+      String josa = BetterKorean.with(ctx.afterRole()).get_으로_로();
 
       String content = "내 권한이 '%s'에서 '%s'%s 변경되었어요."
           .formatted(ctx.beforeRole(), ctx.afterRole(), josa);


### PR DESCRIPTION
## PR 제목 규칙
[알림] (fix/550) 유저 권한 변경 시 변경된 권한이 2번 작성되어 알림 전달

## 📌 PR 내용 요약
- 유저 권한 변경 시 변경된 권한이 2번 작성되어 알림 전달

## 🔗 관련 이슈
- Closes #550

## 🖼️ 스크린샷 (선택) 
<img width="472" height="212" alt="image" src="https://github.com/user-attachments/assets/c7b87dc0-b8f0-4f30-a32f-6f99f4cb5e2c" />

## 🙋 리뷰어에게 요청사항
- 
