### PR TITLE
[Content] (fix/591) 배포환경 배치 401에러 확인을 위해 요청 url, header 로그 추가

### DIFF
--- a/src/main/java/com/codeit/mopl/batch/tmdb/base/config/WebClientConfig.java
+++ b/src/main/java/com/codeit/mopl/batch/tmdb/base/config/WebClientConfig.java
@@ -1,5 +1,6 @@
 package com.codeit.mopl.batch.tmdb.base.config;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -8,6 +9,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.client.WebClient;
 
+@Slf4j
 @Configuration
 public class WebClientConfig {
 
@@ -24,6 +26,11 @@ public class WebClientConfig {
         .baseUrl(BASE_URL)
         .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer "+TOKEN)
         .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+        .filter((request, next) -> {
+          log.info("[TMDB] → Request URL = {}", request.url());
+          request.headers().forEach((k, v) -> log.info("[TMDB] → Header {} = {}", k, v));
+          return next.exchange(request);
+        })
         .build();
   }
 }


### PR DESCRIPTION
## 📌 PR 내용 요약
- 배포환경 배치 401에러 확인을 위해 요청 url, header 로그 추가

## 🔗 관련 이슈
- Closes #528

## 🖼️ 스크린샷 (선택)


## 📚 참고자료 (선택)
- 

## 🙋 리뷰어에게 요청사항
- 
