### PR TITLE
[컨텐츠 (OpenSearch)] (FIX/602) OpenSearch에서 contentType으로 필터링 안되는 버그 

### DIFF
--- a/src/main/java/com/codeit/mopl/search/service/OpenSearchService.java
+++ b/src/main/java/com/codeit/mopl/search/service/OpenSearchService.java
@@ -4,7 +4,6 @@ import com.codeit.mopl.domain.content.dto.request.ContentSearchRequest;
 import com.codeit.mopl.domain.content.dto.response.ContentDto;
 import com.codeit.mopl.domain.content.dto.response.CursorResponseContentDto;
 import com.codeit.mopl.domain.content.entity.Content;
-import com.codeit.mopl.domain.content.entity.ContentType;
 import com.codeit.mopl.domain.content.entity.SortDirection;
 import com.codeit.mopl.exception.content.ContentErrorCode;
 import com.codeit.mopl.exception.content.ContentOsStorageException;
@@ -122,9 +121,9 @@ public class OpenSearchService {
 
     // typeEqual
     if (request.getTypeEqual() != null) {
-        String value = ContentType.fromType(request.getTypeEqual()).name();
+        String value = request.getTypeEqual();
         boolQueryBuilder.filter(f -> f.term(t -> t
-            .field("contentType")
+            .field("type")
             .value(FieldValue.of(value))
         ));
     }


### PR DESCRIPTION
## PR 제목 규칙
[컨텐츠 (OpenSearch)] (FIX/602) OpenSearch에서 contentType으로 필터링 안되는 버그 

## 📌 PR 내용 요약
- OpenSearch에서 contentType으로 필터링 안되는 버그 고침 (`OpenSearchService`에서 고침)

## 🔗 관련 이슈
- Closes #602

## 🖼️ 스크린샷 (선택)


## 📚 참고자료 (선택)
- 

## 🙋 리뷰어에게 요청사항
- 
